### PR TITLE
Remove busted regex in buildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,5 @@
 .Rproj.user
-^\.travis.\yml$
+.travis.yml
 cran-comments.md
 revdep/
 README.Rmd

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@ cran-comments.md
 revdep/
 README.Rmd
 test-I2.R
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 inst/
 dat.rda
+.Rproj.user

--- a/R/I2.R
+++ b/R/I2.R
@@ -54,7 +54,7 @@ I2 <- function(model, v, ME = FALSE, sims = 1500, phylo = FALSE){
   	}
 
   	if("rma.mv" %in% class(model) | "rma" %in% class(model)){
-  		#Monte Carlo Simulations
+  		# Monte Carlo Simulations
 		# From metafor extract the important statistics
   		sigma2 <- matrix(model$sigma2, nrow = 1, ncol = length(model$sigma2))
   		colnames(sigma2) <- model$s.names
@@ -73,11 +73,12 @@ I2 <- function(model, v, ME = FALSE, sims = 1500, phylo = FALSE){
 		Vt <- rowSums(Sims)  # remove Vw
 		
 		# For each variance component divide by the total variance. Note this needs to be fixed for phylo, but does deal with variable random effects.
-		 I2_re       <- Sims / VT
-		 I2_total   <- Vt / VT
+		 I2_re <- Sims / VT
+		 I2_total <- data.frame(Vt / VT)
 
 		  if(phylo == FALSE){
-		  	tmpMatrix <- cbind(I2_re[,-match("obs", colnames(I2_re))], total = I2_total)
+		  	tmpMatrix <- data.frame(I2_re[, -match("obs", colnames(I2_re))], total = I2_total)
+		  	names(tmpMatrix) = c(colnames(I2_re)[!colnames(I2_re) %in% 'obs'], 'total')
 		   }else{
 		  	I2_phylo <- Sims[, match(phylo, colnames(sigma2))] / Vt
 		  	 tmpMatrix <- cbind(I2_re[,-match("obs", colnames(I2_re))], phylo = I2_phylo, total = I2_total)


### PR DESCRIPTION
Yo! This huge change just ditches the regex for excluding `.travis.yml`, because it was preventing the use of `install_github`, which complained & exited (for me anyway?). Shouldn't miss it since it you only ever need the one travis config file, but ignore if I'm missing something obvious. 